### PR TITLE
Fix Mail::Pyzor::Client connection failures due to UDP socket re-use

### DIFF
--- a/lib/Mail/Pyzor/Client.pm
+++ b/lib/Mail/Pyzor/Client.pm
@@ -348,16 +348,16 @@ sub _send_packet {
 
 sub _get_connection_or_die {
     my ($self) = @_;
-    $self->{'_sock'} ||= IO::Socket::INET->new(
+    my $sock = IO::Socket::INET->new(
         'PeerHost' => $self->{'_server_host'},
         'PeerPort' => $self->{'_server_port'},
         'Proto'    => 'udp'
     );
 
-    if ( !$self->{'_sock'} ) {
+    if ( !$sock ) {
         die "Cannot connect to $self->{'_server_host'}:$self->{'_server_port'}: $@ $!";
     }
-    return $self->{'_sock'};
+    return $sock;
 }
 
 sub _sign_msg {


### PR DESCRIPTION
Case CPANEL-31216:

Reusing the socket object is causing multiple processes attempting
to use the same socket.  Sometimes one process reads the response
meant for another process.  Creating a single socket object per
request, and letting it get de-allocated, prevents this issue.

(cherry picked from commit 676c8f841bbac1f86ad0bbe0b114a6931467242e)
Signed-off-by: Nicolas R <nicolas@atoomic.org>